### PR TITLE
Doc styling updates.

### DIFF
--- a/endpoints/pages/create.md
+++ b/endpoints/pages/create.md
@@ -1,34 +1,11 @@
 # Create Page
 
-  This endpoint works for creating a new page in a specific Site.
+Use the `/api/v1/pages` endpoint for creating a new page on a specific site.
 
-* **URL**
+## Request Payload
 
-  /api/{version}/pages
+You must `POST` the content used to create the page. An example of a request payload is:
 
-* **Method:**
-  
-  `POST`
-  
-*  **Headers**
-
-   **Required:**
- 
-   `x-api-key=[string]` - API Key required to authenticate and allow request to perform the operation </br>
-   `ddc-site-id=[string]` - Site ID that the request is aimed to perform changes
-
-*  **URL Params**
-
-   **Required:**
- 
-   `version=[string]` - API version, a string that specifies the version of the API the developer wants to contact. Current valid value is `v1`
-
-   **Optional:**
- 
-   No optional parameters supported.
-
-* **Data Params**
-[See available pages](#available-pages) for available layouts and their windowIds
 ```
   {
     "pageId":  "v9_CONTENT_RAW_FULL_WIDTH_DEFAULT_V1_1", 
@@ -58,27 +35,34 @@
     }
   }
 ```
-* **Success Response:**
 
-  * **Code:** 201 <br />
-    **Content:** `{ url: "{domain}/your-created-page.html" }`
+The `pageId` property should be supplied in the payload to the API. You can chose from the pages below and send content associated with each windowId in the `content` block. If content is omitted pages will render as blank pages.
+
+In the example payload above you can see we provided pageId `v9_CONTENT_RAW_FULL_WIDTH_DEFAULT_V1_1` and content windowId `raw-content1`. 
  
-* **Partial Content Success Response:**
-  * **Code:** 206 <br />
-    **Content:** `{ url: "{domain}/your-created-page.html", message: "Page created but there was an issue saving the following: <issueEncountered>" }`
-> *In the event of a partial content response do not worry your page has been created. You can try to update your pages content using the [PATCH](./update.md) end point and providing the URL returned from this end point. 
- 
-* **Error Response:**
+| Page ID | Description | Content Window Ids |
+| --- | --- | --- |
+| v9_CONTENT_RAW_FULL_WIDTH_DEFAULT_V1_1 | Full width page with a page title element and a single raw content area | raw-content1 |
+| v9_CONTENT_RAW_FULL_WIDTH_NO_TITLE_V1_1 | Full width page with a single raw content area | raw-content1 |
+  
+## HTTP Headers
 
-  * **Code:** 406 NOT ACCEPTABLE <br />
-    **Content:** TBD
+| Name | Required | Description |
+| --- | --- | --- |
+| x-api-key | Yes | API Key required to authenticate and allow request to perform the operation |
+| ddc-site-id | Yes | Site ID that the request is aimed to perform changes |
 
-  OR
+## Responses
 
-  * **Code:** 500 INTERNAL SERVER ERROR <br />
-    **Content:** TBD
+| Code | Use | Content | Addt'l Info |
+| --- | --- | --- | --- |
+| 201 | Success | `{ url: "{domain}/your-created-page.html" }` | |
+| 206 | Partial Content Success | `{ url: "{domain}/your-created-page.html", message: "Page created but there was an issue saving the following: <issueEncountered>" }` | Do not worry your page has been created. You can try to update your pages content using the [PATCH](./update.md) end point and providing the URL returned from this end point. |
+| 406 | Not Acceptable | TBD | |
+| 500 | Internal Server Error | TBD | |
 
-* **Sample Call:**
+## Sample Call
+
 ```
  curl --location --request POST 'https://www.domain.com/api/v1/pages' \
 --header 'Accept: application/json' \
@@ -113,16 +97,3 @@
         }
       }'
 ```
-
-### Available Pages
-**pageId** property should be supplied in the payload to the API. You can chose from the pages below and send content associated with each windowId in the **content** block. If content is omitted pages will render as blank pages. <br/> In the example payload above you can see we provided pageId: v9_CONTENT_RAW_FULL_WIDTH_DEFAULT_V1_1 and content windowId "raw-content1" 
- 
-| PageID | Description | Content WindowIds |
-| ----- | ----- | ----- |
-| v9_CONTENT_RAW_FULL_WIDTH_DEFAULT_V1_1 | Full width page with a page title element and a single raw content area | "raw-content1" |
-| v9_CONTENT_RAW_FULL_WIDTH_NO_TITLE_V1_1 | Full width page with a single raw content area | "raw-content1" |
-
-
-* **Notes:**
-
- This endpoint is still under construction and continuous improvement, so please note that the specs and definitions may change.

--- a/endpoints/pages/create.md
+++ b/endpoints/pages/create.md
@@ -51,6 +51,7 @@ In the example payload above you can see we provided pageId `v9_CONTENT_RAW_FULL
 | --- | --- | --- |
 | x-api-key | Yes | API Key required to authenticate and allow request to perform the operation |
 | ddc-site-id | Yes | Site ID that the request is aimed to perform changes |
+| x-disable-locale-validation | No | Pass as true for the API to ignore missing locale errors |
 
 ## Responses
 

--- a/endpoints/pages/delete.md
+++ b/endpoints/pages/delete.md
@@ -1,40 +1,39 @@
-**Delete Page**
-----
-Method call to remove a sitemap entry from a given site
+# Delete Page
 
-* **URL**
-/api/{version}/pages
+Use the DELETE method on `/api/v1/pages` endpoint for delete page by path on a specific site.
 
-* **Method:**
-  `DELETE`
-  
-*  **Headers**
+## URL Parameters
 
-   **Required:**
- 
-   `x-api-key=[string]` - API Key required to authenticate and allow request to perform the operation </br>
-   `ddc-site-id=[string]` - Site ID that the request is aimed to perform changes
-  
-* **URL Params**
-  
-  **Required:**
- 
-   `path=[string]`
+You must send a request with the path as a query parameter
 
-* **Success Response:**
+```
+  /api/v1/pages?page=/delete-me.htm
+```
 
-  * **Code:** 200 <br />
-    **Content:** `DELETE request processed for [siteId] and [page_alias]`
- 
-* **Error Response:**
+## HTTP Headers
 
-  * **Code:** 400 BAD REQUEST <br />
-    **Content:** `Payload invalid: Path required for DELETE action`
+| Name | Required | Description |
+| --- | --- | --- |
+| x-api-key | Yes | API Key required to authenticate and allow request to perform the operation |
+| ddc-site-id | Yes | Site ID that the request is aimed to perform changes |
 
-  OR
+## Responses
 
-  * **Code:** 500 INTERNAL SERVER ERROR <br />
-    **Content:** Server Error Message
+| Code | Error | Message | Addt'l Info |
+| --- | --- | --- | --- |
+| 200 | Success | DELETE request processed for [siteId] and [page_alias] | |
+| 400 | Bad Request | Payload invalid: Path required for DELETE action | |
+| 500 | Internal Server Error | TBD | |
+
+## Sample Call
+
+```
+ curl --location --request DELETE 'https://www.domain.com/api/v1/pages?path=/page-to-delete.htm' \
+--header 'Accept: application/json' \
+--header 'x-api-key: yourProvidedAPIKey' \
+--header 'ddc-site-id: targetSiteId' \
+--header 'Content-Type: application/json' \
+```
 
 * **Notes:**
 

--- a/endpoints/pages/update.md
+++ b/endpoints/pages/update.md
@@ -1,34 +1,14 @@
 # Update Page Content/Metadata
 
-  This endpoint works for updating content and metadata on an already existing page.
+This endpoint works for updating content and metadata on an already existing page.
 
-* **URL**
+`/api/{version}/pages?path={path}`
+## Query Param 
+*Optional:*
+**path** - path of page to update, if not provided payload must contain a paths by locale property as seen below
+## Request Payload
 
-  /api/{version}/pages?path={path}
-
-* **Method:**
-  
-  `PATCH`
-  
-*  **Headers**
-
-   **Required:**
- 
-   `x-api-key=[string]` - API Key required to authenticate and allow request to perform the operation </br>
-   `ddc-site-id=[string]` - Site ID that the request is aimed to perform changes
-
-*  **URL Params**
-
-   **Required:**
- 
-   `version=[string]` - API version, a string that specifies the version of the API the developer wants to contact. Current valid value is `v1`
-
-   **Optional:**
-   
-   `path=[string]` - Path to perform updates on. If this does not exist Update will fallback to payload.path
-
-* **Data Params**
-
+You must `PATCH` the content and/or metadata to update on the page. An example of a request payload is:
 ```
   {
     "path": {
@@ -52,26 +32,28 @@
     }
   }
 ```
-* **Success Response:**
 
-  * **Code:** 201 <br />
-    **Content:** `{ url: "{domain}/your-updated-page.html" }`
- 
-* **Error Response:**
+## HTTP Headers
 
-  * **Code:** 406 NOT ACCEPTABLE <br />
-    **Content:** TBD
+| Name | Required | Description |
+| --- | --- | --- |
+| x-api-key | Yes | API Key required to authenticate and allow request to perform the operation |
+| ddc-site-id | Yes | Site ID that the request is aimed to perform changes |
+| x-disable-locale-validation | No | Pass as true for the API to ignore missing locale errors |
 
-  OR
+## Responses
 
-  * **Code:** 500 INTERNAL SERVER ERROR <br />
-    **Content:** TBD
-    
-> *You may see messages about failures to post metadata and/or content. Your page was still created and you can use the Composer interface to fill out any missing content.*
+| Code | Use | Content | Addt'l Info |
+| --- | --- | --- | --- |
+| 201 | Success | `{ url: "{domain}/your-created-page.html" }` | |
+| 206 | Partial Content Success | `{ url: "{domain}/your-created-page.html", message: "There was an issue saving the following: <issueEncountered>" }` | |
+| 406 | Not Acceptable | TBD | |
+| 500 | Internal Server Error | TBD | |
 
-* **Sample Call:**
+## Sample Call
+
 ```
- curl --location --request POST 'https://www.domain.com/api/v1/pages?path=/existing-page-path.htm' \
+ curl --location --request PATCH 'https://www.domain.com/api/v1/pages?path=/existing-page-path.htm' \
 --header 'Accept: application/json' \
 --header 'x-api-key: yourProvidedAPIKey' \
 --header 'ddc-site-id: yoursiteid' \
@@ -95,6 +77,7 @@
         }
       }'
 ```
+
 
 * **Notes:**
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,14 +1,14 @@
 # Release Notes
 All notable releases to this project will be documented in this file. 
 
-this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3/21/2023]
+**Added**
+* X-CoxAuto-Correlation-Id tracing header
+* page per site limitations
+* PATCH mechanism for updating content/metadata 
+* Content Locale validation with *x-disable-locale-validation* header to bypass 
 
-# V1 
-## [0.0.3] - Unreleased
-* PATCH mechanism
-* Content Locale validation 
-
-## [0.0.2]
+## [3/12/2023]
 **Updated**
 * API key authentication to use query instead of scan
 * Release notes and Documentation
@@ -16,7 +16,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * POST mechanism
 * DELETE mechanism 
 
-## [0.0.1] 
+## [2/14/2023]
 **Added**
 * API key authentication
 * Release notes and Documentation

--- a/release-notes.md
+++ b/release-notes.md
@@ -3,7 +3,6 @@ All notable releases to this project will be documented in this file.
 
 ## [3/21/2023]
 **Added**
-* X-CoxAuto-Correlation-Id tracing header
 * page per site limitations
 * PATCH mechanism for updating content/metadata 
 * Content Locale validation with *x-disable-locale-validation* header to bypass 
@@ -13,6 +12,7 @@ All notable releases to this project will be documented in this file.
 * API key authentication to use query instead of scan
 * Release notes and Documentation
 **Added**
+* X-CoxAuto-Correlation-Id tracing header
 * POST mechanism
 * DELETE mechanism 
 


### PR DESCRIPTION
I wanted to propose a different style for the endpoint documentation. I didn't know how to do that without just mocking it up. Feel free to take it or leave it. I tried not to change the content, however I did make a couple updates:

- Removed references to `[string]`. All headers, paths, url parameters, etc... are strings, so it didn't seem to add a lot of value.
- Removed the URL Params section. The only thing under it was the version in the path, which is not a url parameter. So, I added the version to the one place it was referenced in the api path. If we ever have a v2 of the entire API (which that particular version corresponds to), then I think we'd have separate v1 and v2 documentation.
- Removed the note about this being under construction. That should be a given or can be clearly stated once at the top-level of the documentation.

The diff of markdown makes it hard to tell what's going on. It's probably best to compare the old document to the new one in separate tabs. Thoughts? Again, feel free to close without merging if the team prefers the former style.